### PR TITLE
Allow scrolling horizontally on cards for small screens

### DIFF
--- a/assets/css/cards.css
+++ b/assets/css/cards.css
@@ -77,6 +77,7 @@
   box-shadow: var(--shadow-light);
   cursor: pointer;
   height: 100%;
+  overflow-x: auto;
   padding: 10px 35px 10px;
   margin-bottom: 30px;
   transition: all .2s ease;


### PR DESCRIPTION
I was testing on mobile and noticed that the table was getting cut off on the right side. There was an overflow (image below) but no rule; this PR adds that rule. My browser was hiccuping while testing locally, so I couldn't verify that this works other than using dev tools while browsing staging.

![image](https://user-images.githubusercontent.com/9289652/235819476-455c23bd-6db2-459b-9905-c19549312e26.png)
